### PR TITLE
Add ISO upload option and better error display

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Screenshot 3:
 
 ![screenshot-3](images/screenshot-3.png)
 
-## Used Lbraries
+## Used Libraries
 
 - jQuery 3.7.1 - [jquery.com](https://jquery.com)
 - Bootstrap 5.3.3 - [getbootstrap.com](https://getbootstrap.com)

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -43,7 +43,41 @@ document.addEventListener("DOMContentLoaded", function() {
         });
         container.appendChild(table);
     })
-    .catch(error => console.error('Error fetching data:', error));
+    .catch(error => {
+        const container = document.querySelector('#iso-list');
+        container.innerHTML = `<div class="alert alert-danger">Failed to load ISO data: ${error.message}</div>`;
+        console.error('Error fetching data:', error);
+    });
+
+    const uploadForm = document.querySelector('#upload-form');
+    if (uploadForm) {
+        uploadForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            const fileInput = document.querySelector('#isoFile');
+            const status = document.querySelector('#upload-status');
+            if (!fileInput.files.length) {
+                status.innerHTML = '<div class="alert alert-warning">Please select a file</div>';
+                return;
+            }
+            const formData = new FormData();
+            formData.append('file', fileInput.files[0]);
+
+            fetch(`http://${window.location.hostname}/api/upload`, {
+                method: 'POST',
+                body: formData
+            })
+            .then(r => {
+                if (!r.ok) throw new Error('Upload failed');
+                return r.text();
+            })
+            .then(() => {
+                status.innerHTML = '<div class="alert alert-success">Upload successful</div>';
+            })
+            .catch(err => {
+                status.innerHTML = `<div class="alert alert-danger">Upload failed: ${err.message}</div>`;
+            });
+        });
+    }
 });
 
 function viewISO(id) {

--- a/default.conf
+++ b/default.conf
@@ -27,4 +27,25 @@ server {
             return 204;
         }
     }
+
+    location /api/upload {
+        proxy_pass http://1.2.3.4:26000/upload;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain';
+            return 204;
+        }
+    }
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,15 @@
                 <!-- ISO data will be populated here by loader.js -->
             </div>
         </div>
+        <div class="row mt-3">
+            <div class="col-12">
+                <form id="upload-form" class="input-group">
+                    <input type="file" class="form-control" id="isoFile" accept=".iso">
+                    <button class="btn btn-success" type="submit">Upload</button>
+                </form>
+                <div id="upload-status" class="mt-2"></div>
+            </div>
+        </div>
         <div class="row">
             <div class="col-12" id="iframe-viewer">
                 <!-- ISO data will be populated here by loader.js -->


### PR DESCRIPTION
## Summary
- fix README typo for **Used Libraries** heading
- show a user-visible error in the ISO table when API requests fail
- add an upload form to allow ISO uploads
- support upload endpoint in loader script
- expose `/api/upload` in nginx config

